### PR TITLE
fixed window_mode compatible

### DIFF
--- a/src/proxyIDirect3DDevice9.cpp
+++ b/src/proxyIDirect3DDevice9.cpp
@@ -4058,7 +4058,8 @@ HRESULT proxyIDirect3DDevice9::Reset ( D3DPRESENT_PARAMETERS *pPresentationParam
 		}
 
 		// init our window mode
-		proxyID3DDevice9_InitWindowMode( pPresentationParameters );
+		if (set.window_mode)
+			proxyID3DDevice9_InitWindowMode( pPresentationParameters );
 
 		// update the global Present Param struct AFTER original reset, only if it's ok
 		pPresentParam = *pPresentationParameters;


### PR DESCRIPTION
Я не знаю английский, а ты знаешь русский, так что читай на русском.

Если в собе выключен оконный режим, но игру запустить в окне (через лаунчер могайки или мой), то при вызове метода Reset творится пиздец. Пиздец этот поправим добавленным мной условием, при этом работа соба от этого не страдает. Единственный оставшийся недостаток (оставшийся - значит был до моего вмешательства) это то что оконный режим не согласован с собом, т.е. пиздец от которого я тут отхожу можно повторить переключив оконный режим в меню собейта. Но не ссы, я имею желание это пофиксить, так что оно будет тоже исправлено.