### PR TITLE
update fix window_mode compatible

### DIFF
--- a/src/ini.h
+++ b/src/ini.h
@@ -304,7 +304,6 @@ struct settings
 	// ignored because of the function being removed
 	int						window_mode;
 	int						window_mode_titlebar;
-	int						window_mode_sided;
 
 	int						flickering_problem;
 

--- a/src/ini.h
+++ b/src/ini.h
@@ -304,6 +304,7 @@ struct settings
 	// ignored because of the function being removed
 	int						window_mode;
 	int						window_mode_titlebar;
+	int						window_mode_sided;
 
 	int						flickering_problem;
 

--- a/src/proxyIDirect3D9.cpp
+++ b/src/proxyIDirect3D9.cpp
@@ -153,8 +153,9 @@ HRESULT __stdcall proxyIDirect3D9::CreateDevice ( UINT Adapter, D3DDEVTYPE Devic
 	HRESULT hRes;
 
 	ulFullScreenRefreshRate = pPresentationParameters->FullScreen_RefreshRateInHz;
+	set.window_mode_sided = *(byte*)0x746225 == 0x90;
 
-	if ( set.window_mode )
+	if ( set.window_mode && !set.window_mode_sided)
 	{
 		int x, y;
 		x = GetSystemMetrics( SM_CXSCREEN );

--- a/src/proxyIDirect3D9.cpp
+++ b/src/proxyIDirect3D9.cpp
@@ -153,9 +153,8 @@ HRESULT __stdcall proxyIDirect3D9::CreateDevice ( UINT Adapter, D3DDEVTYPE Devic
 	HRESULT hRes;
 
 	ulFullScreenRefreshRate = pPresentationParameters->FullScreen_RefreshRateInHz;
-	set.window_mode_sided = *(byte*)0x746225 == 0x90;
 
-	if ( set.window_mode && !set.window_mode_sided)
+	if ( set.window_mode && *(byte*)0x746225 != 0x90)
 	{
 		int x, y;
 		x = GetSystemMetrics( SM_CXSCREEN );

--- a/src/proxyIDirect3DDevice9.cpp
+++ b/src/proxyIDirect3DDevice9.cpp
@@ -3383,6 +3383,12 @@ void proxyID3DDevice9_InitWindowMode ( D3DPRESENT_PARAMETERS *pPresentationParam
 {
 	traceLastFunc( "proxyID3DDevice9_InitWindowMode()" );
 
+	if (set.window_mode_sided) {
+		g_isRequestingWindowModeToggle = false;
+		g_isRequesting_RwD3D9ChangeVideoMode = false;
+		return;
+	}
+
 	// window mode toggle, flips set.window_mode bit
 	if ( g_isRequestingWindowModeToggle )
 	{
@@ -4058,8 +4064,7 @@ HRESULT proxyIDirect3DDevice9::Reset ( D3DPRESENT_PARAMETERS *pPresentationParam
 		}
 
 		// init our window mode
-		if (set.window_mode)
-			proxyID3DDevice9_InitWindowMode( pPresentationParameters );
+		proxyID3DDevice9_InitWindowMode( pPresentationParameters );
 
 		// update the global Present Param struct AFTER original reset, only if it's ok
 		pPresentParam = *pPresentationParameters;

--- a/src/proxyIDirect3DDevice9.cpp
+++ b/src/proxyIDirect3DDevice9.cpp
@@ -3383,7 +3383,7 @@ void proxyID3DDevice9_InitWindowMode ( D3DPRESENT_PARAMETERS *pPresentationParam
 {
 	traceLastFunc( "proxyID3DDevice9_InitWindowMode()" );
 
-	if (set.window_mode_sided) {
+	if (*(byte*)0x746225 == 0x90) {
 		g_isRequestingWindowModeToggle = false;
 		g_isRequesting_RwD3D9ChangeVideoMode = false;
 		return;


### PR DESCRIPTION
Немного изменил подход к фиксу, ну и по сути улучшил его. Соб при создание девайса проверяет, наличие одного из патчей оконного режима, и если он установлен, то отключает возможность смены оконного/полноэкранного режима через соб. Т.е. кнопка 'toggle Window mode' из Misc перестает реагировать на нажатие, и вместе с тем не вызывает багов окна, которые она вызывала в прошлом фиксе. Если получится, то в будущем выкачу еще один апдейт этого фикса, где реализую не только возможность запускать игру с собом в окне через сторонний лаунчер, а еще и возможность перехода после этого в полноэкранный/оконный режим через соб